### PR TITLE
Add immune-related PTMs

### DIFF
--- a/github_upload_package/PEPTIDE_ANALYSIS_README.md
+++ b/github_upload_package/PEPTIDE_ANALYSIS_README.md
@@ -109,6 +109,8 @@ python example_usage.py
 | Methyl[K] | K | 0.05 | -3.76 |
 | Dimethyl[K] | K | -0.55 | -3.96 |
 | Trimethyl[K] | K | -1.00 | -4.06 |
+| Ubiquitination[K] | K | NA | -5.0 |
+| Citrullination[R] | R | -6.5 | -1.0 |
 
 ## 文件结构
 

--- a/github_upload_package/README.md
+++ b/github_upload_package/README.md
@@ -44,7 +44,7 @@ python tumor_vs_normal_ptm_analysis.py
 
 ## 📊 功能特点
 
-- ✅ **专业的PTM分析**: 支持9种常见修饰类型
+ - ✅ **专业的PTM分析**: 支持11种常见修饰类型（新增Ubiquitination和Citrullination）
 - ✅ **统计严谨**: 非参数检验 + 效应量分析
 - ✅ **可视化专业**: 符合学术发表标准
 - ✅ **断点续传**: 支持中断后继续分析

--- a/github_upload_package/peptide_group_analysis.py
+++ b/github_upload_package/peptide_group_analysis.py
@@ -54,7 +54,8 @@ class PeptideGroupAnalyzer:
         self.target_modifications = [
             'Phospho[S]', 'Phospho[T]', 'Phospho[Y]',
             'Acetyl[K]', 'Methyl[K]', 'Dimethyl[K]', 'Trimethyl[K]',
-            'Deamidated[N]', 'Deamidated[Q]'
+            'Deamidated[N]', 'Deamidated[Q]',
+            'Ubiquitination[K]', 'Citrullination[R]'
         ]
 
         # 理化性质列名

--- a/github_upload_package/peptide_group_analysis_modified.py
+++ b/github_upload_package/peptide_group_analysis_modified.py
@@ -55,7 +55,8 @@ class PeptideGroupAnalyzer:
         self.target_modifications = [
             'Phospho[S]', 'Phospho[T]', 'Phospho[Y]',
             'Acetyl[K]', 'Methyl[K]', 'Dimethyl[K]', 'Trimethyl[K]',
-            'Deamidated[N]', 'Deamidated[Q]'
+            'Deamidated[N]', 'Deamidated[Q]',
+            'Ubiquitination[K]', 'Citrullination[R]'
         ]
 
         # 理化性质列名

--- a/github_upload_package/peptide_properties_analyzer.py
+++ b/github_upload_package/peptide_properties_analyzer.py
@@ -196,6 +196,23 @@ class PeptidePropertiesAnalyzer:
                 'new_hydro_ei': 0.26,
                 'unimod_id': 'bdmapp',
                 'delta_mass': 0.0  # 未知质量变化
+            },
+            # 与肿瘤免疫相关的修饰
+            'Ubiquitination[K]': {
+                'target_aa': 'K',
+                'new_pka': None,
+                'new_hydro_kd': -7.0,
+                'new_hydro_ei': -5.0,
+                'unimod_id': 'gg',
+                'delta_mass': 114.043
+            },
+            'Citrullination[R]': {
+                'target_aa': 'R',
+                'new_pka': 6.0,
+                'new_hydro_kd': -1.0,
+                'new_hydro_ei': -0.5,
+                'unimod_id': 'cit',
+                'delta_mass': 0.984
             }
         }
         return modifications

--- a/github_upload_package/project_info.json
+++ b/github_upload_package/project_info.json
@@ -28,5 +28,8 @@
     "Methyl[K]",
     "Dimethyl[K]",
     "Trimethyl[K]"
+    ,
+    "Ubiquitination[K]",
+    "Citrullination[R]"
   ]
 }

--- a/github_upload_package/tumor_analysis_core.py
+++ b/github_upload_package/tumor_analysis_core.py
@@ -44,7 +44,8 @@ class TumorAnalysisCore:
         # 目标修饰类型
         self.target_modifications = {
             'Oxidation[M]', 'Acetyl[K]', 'Phospho[S]', 'Phospho[T]', 'Phospho[Y]',
-            'Deamidated[N]', 'Deamidated[Q]', 'Methyl[K]', 'Dimethyl[K]', 'Trimethyl[K]'
+            'Deamidated[N]', 'Deamidated[Q]', 'Methyl[K]', 'Dimethyl[K]', 'Trimethyl[K]',
+            'Ubiquitination[K]', 'Citrullination[R]'
         }
         
         # 修饰类型的中文名称映射
@@ -58,7 +59,9 @@ class TumorAnalysisCore:
             'Deamidated[Q]': '谷氨酰胺脱酰胺',
             'Methyl[K]': '赖氨酸甲基化',
             'Dimethyl[K]': '赖氨酸二甲基化',
-            'Trimethyl[K]': '赖氨酸三甲基化'
+            'Trimethyl[K]': '赖氨酸三甲基化',
+            'Ubiquitination[K]': '赖氨酸泛素化',
+            'Citrullination[R]': '精氨酸瓜氨酸化'
         }
     
     def load_cancer_datasets(self) -> List[str]:

--- a/github_upload_package/tumor_vs_normal_ptm_analysis.py
+++ b/github_upload_package/tumor_vs_normal_ptm_analysis.py
@@ -46,7 +46,8 @@ class TumorNormalPTMAnalyzer:
         self.target_modifications = [
             'Phospho[S]', 'Phospho[T]', 'Phospho[Y]',
             'Acetyl[K]', 'Methyl[K]', 'Dimethyl[K]', 'Trimethyl[K]',
-            'Deamidated[N]', 'Deamidated[Q]'
+            'Deamidated[N]', 'Deamidated[Q]',
+            'Ubiquitination[K]', 'Citrullination[R]'
         ]
         
         # 理化性质列名


### PR DESCRIPTION
## Summary
- expand supported PTM list to include Ubiquitination and Citrullination
- update modification tables with approximate parameters
- enable new PTMs in analysis scripts
- document the additional PTMs in README files and project metadata

## Testing
- `python -m py_compile github_upload_package/peptide_group_analysis.py github_upload_package/peptide_group_analysis_modified.py github_upload_package/peptide_properties_analyzer.py github_upload_package/tumor_analysis_core.py github_upload_package/tumor_vs_normal_ptm_analysis.py`

------
https://chatgpt.com/codex/tasks/task_b_6848001e91188321b4e389eacbc20fb1